### PR TITLE
extract watcher data logic to watcher-data.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,10 +4,9 @@
 * See the accompanying LICENSE file for terms.
 */
 var url = require('url'),
-    net = require('net'),
-    os = require('os'),
     ejs = require('ejs'),
     fs = require('fs'),
+    watcher = require('./watcher'),
     ejsStr;
 
 
@@ -23,87 +22,25 @@ module.exports = function (config) {
     }
 
     return function (req, resp, next) {
-        var socket,
-            msg,
-            response_obj = {},
-            respond;
         if (url.parse(req.url).pathname === config.url) {
-            respond = (config.check) ? config.check(req) : true;
-            if (respond) {
-                socket = net.createConnection(config.socketPath);
-                msg = "";
-                socket.on("data", function (data) {
-                    msg += data;
-                });
-                socket.on("end", function () {
-                    var statuses = JSON.parse(msg);
-                    response_obj.hostname = os.hostname();
-                    response_obj.node_version = process.version;
-                    response_obj.os_type = os.type();
-                    response_obj.os_release = os.release();
-                    response_obj.currentTime = Date.now();
-                    if (process.clusterStartTime) {
-                        //Show Restart Time only if Process has the field clusterStartTime
-                        //this attribute should be set by the cluster master process
-                        response_obj.cluster_start_time = process.clusterStartTime.getTime();
-                        response_obj.cluster_uptime = Math.round((new Date().getTime() - process.clusterStartTime.getTime()) / 1000);
-                    }
-                    response_obj.total_memory = os.totalmem();
-                    response_obj.free_memory = os.freemem();
-                    response_obj.os_loadavg = os.loadavg();
-                    response_obj.worker = [];
-
-                    response_obj.total_requests = 0;
-                    response_obj.total_kbs_transferred = 0;
-                    response_obj.total_kbs_out = 0;
-                    response_obj.total_rps = 0;
-                    Object.keys(statuses).forEach(function(pid) {
-                        response_obj.worker.push({
-                            "pid" : pid,
-                            "cpu" : statuses[pid].curr.cpu,
-                            "mem" : statuses[pid].curr.mem,
-                            "cpu_per_req" : statuses[pid].curr.cpuperreq,
-                            "jiffy_per_req" : statuses[pid].curr.jiffyperreq,
-                            "rps" : statuses[pid].curr.rps,
-                            "events" : statuses[pid].curr.events,
-                            "open_conns" : statuses[pid].curr.oconns,
-                            "open_requests" : statuses[pid].curr.oreqs,
-                            "total_requests" : statuses[pid].curr.reqstotal,
-                            "kbs_out" : statuses[pid].curr.kbs_out,
-                            "kbs_transferred" : statuses[pid].curr.kb_trans,
-                            "start_time" : statuses[pid].curr.utcstart * 1000 //convert sec in millis
-                        });
-                        response_obj.total_requests = response_obj.total_requests + statuses[pid].curr.reqstotal;
-                        response_obj.total_kbs_transferred = response_obj.total_kbs_transferred + statuses[pid].curr.kb_trans;
-                        response_obj.total_kbs_out = response_obj.total_kbs_out + statuses[pid].curr.kbs_out;
-                        response_obj.total_rps = response_obj.total_rps + statuses[pid].curr.rps;
-                    });
-                    if (config.responseContentType === 'json') {
-                        resp.writeHead(200, {
-                            'Content-Type' : 'application/json'
-                        });
-                        resp.end(JSON.stringify(response_obj));
-                    } else {
-                        resp.writeHead(200, {
-                            'Content-Type' : 'text/html'
-                        });
-                        resp.end(ejs.render(ejsStr, response_obj));
-                    }
-                });
-
-                socket.on("error", function () {
-                    resp.writeHead(500, {
-                        'Content-Type' : 'text/plain'
-                    });
-                    resp.end("Watcher is not running");
-                });
-
-                socket.on("close", function (error) {
-                    if (error) {
+            if (typeof config.check !== "function" || config.check(req)) {
+                watcher(config.socketPath, function (err, data) {
+                    if (err) {
+                        // how do you diagnose a real errwatcherDataor?
                         resp.writeHead(500, {
                             'Content-Type' : 'text/plain'
                         });
                         resp.end("Watcher is not running");
+                    } else if (config.responseContentType === 'json') {
+                        resp.writeHead(200, {
+                            'Content-Type' : 'application/json'
+                        });
+                        resp.end(JSON.stringify(data));
+                    } else {
+                        resp.writeHead(200, {
+                            'Content-Type' : 'text/html'
+                        });
+                        resp.end(ejs.render(ejsStr, data));
                     }
                 });
             } else {

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -1,0 +1,75 @@
+var os = require("os"),
+    net = require("net"),
+    bl = require("bl");
+
+module.exports = function (socketPath, _callback) {
+    var socket = net.createConnection(socketPath),
+        response_obj = {};
+
+    // because there's a possibility of multiple calls from the events
+    // ensure it can't trigger a double-callback
+    function callback (err, data) {
+        if (_callback) {
+            _callback(err, data);
+            _callback = null;
+        }
+    }
+
+    function collector (err, data) {
+        if (err) {
+            return callback(err);
+        }
+
+        var statuses = JSON.parse(data.toString());
+        response_obj.hostname = os.hostname();
+        response_obj.node_version = process.version;
+        response_obj.os_type = os.type();
+        response_obj.os_release = os.release();
+        response_obj.currentTime = Date.now();
+        if (process.clusterStartTime) {
+            //Show Restart Time only if Process has the field clusterStartTime
+            //this attribute should be set by the cluster master process
+            response_obj.cluster_start_time = process.clusterStartTime.getTime();
+            response_obj.cluster_uptime = Math.round((new Date().getTime() - process.clusterStartTime.getTime()) / 1000);
+        }
+        response_obj.total_memory = os.totalmem();
+        response_obj.free_memory = os.freemem();
+        response_obj.os_loadavg = os.loadavg();
+        response_obj.worker = [];
+
+        response_obj.total_requests = 0;
+        response_obj.total_kbs_transferred = 0;
+        response_obj.total_kbs_out = 0;
+        response_obj.total_rps = 0;
+        Object.keys(statuses).forEach(function(pid) {
+            response_obj.worker.push({
+                "pid" : pid,
+                "cpu" : statuses[pid].curr.cpu,
+                "mem" : statuses[pid].curr.mem,
+                "cpu_per_req" : statuses[pid].curr.cpuperreq,
+                "jiffy_per_req" : statuses[pid].curr.jiffyperreq,
+                "rps" : statuses[pid].curr.rps,
+                "events" : statuses[pid].curr.events,
+                "open_conns" : statuses[pid].curr.oconns,
+                "open_requests" : statuses[pid].curr.oreqs,
+                "total_requests" : statuses[pid].curr.reqstotal,
+                "kbs_out" : statuses[pid].curr.kbs_out,
+                "kbs_transferred" : statuses[pid].curr.kb_trans,
+                "start_time" : statuses[pid].curr.utcstart * 1000 //convert sec in millis
+            });
+            response_obj.total_requests = response_obj.total_requests + statuses[pid].curr.reqstotal;
+            response_obj.total_kbs_transferred = response_obj.total_kbs_transferred + statuses[pid].curr.kb_trans;
+            response_obj.total_kbs_out = response_obj.total_kbs_out + statuses[pid].curr.kbs_out;
+            response_obj.total_rps = response_obj.total_rps + statuses[pid].curr.rps;
+        });
+
+        callback(null, response_obj);
+    }
+
+    socket.pipe(bl(collector));
+    socket.on("close", function (error) {
+        if (error) {
+            callback(error);
+        }
+    });
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "version": "0.0.1",
     "dependencies": {
 	"process-watcher": "*",
-        "ejs": "~0.8.3"
+        "ejs": "~0.8.3",
+        "bl": "~0.6.0"
     },
     "devDependencies": {
         "express": "~3.3.5",


### PR DESCRIPTION
I'm guessing it's going to be tricky getting a major PR like this in through complex corporate policies and perhaps you're not interested anyway so I'll understand if this can't land!

Basically wanted to get at the watcher data decoding logic because I don't use express. It's now in watcher.js so could be used via `require('mod_statuspage/lib/watcher')`.

I've also switched to using proper streaming data collection via _bl_ and it's also used to stream data to the module for testing rather than using the older streams1 "data" interface.
